### PR TITLE
fix: auto literal codegen

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
         args: ['--maxkb=1000']
@@ -10,7 +10,7 @@ repos:
       - id: pretty-format-json
         args: ['--autofix']
   - repo: https://github.com/psf/black
-    rev: 24.8.0
+    rev: 25.1.0
     hooks:
       - id: black
   - repo: https://github.com/cheshirekow/cmake-format-precommit
@@ -21,7 +21,7 @@ repos:
       - id: cmake-lint
         additional_dependencies: [pyyaml>=5.1]
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v18.1.8
+    rev: v20.1.5
     hooks:
       - id: clang-format
         types_or: [c++, c]

--- a/src/code_generation.cmake
+++ b/src/code_generation.cmake
@@ -283,5 +283,7 @@ macro(_toolbelt_embed_lines line_end hex)
     string(STRIP "${enclose_start}${value}${enclose_end}" value)
 
     # No line ending for last element. Escape to treat special characters.
-    string(REGEX REPLACE "\\${line_end}$" "" value "${value}")
+    if(NOT "${line_end}" STREQUAL "")
+        string(REGEX REPLACE "\\${line_end}$" "" value "${value}")
+    endif()
 endmacro()

--- a/tests/resources/embed/main.cpp
+++ b/tests/resources/embed/main.cpp
@@ -23,7 +23,8 @@ int main() {
     std::cout << application::detail::auto_literal_namespace;
     std::cout << application::detail::const_literal_namespace;
     std::cout << std::string{
-        reinterpret_cast<const char *>(application::detail::byte_array_namespace
+        reinterpret_cast<const char *>(
+            application::detail::byte_array_namespace
         ),
         sizeof(application::detail::byte_array_namespace)
     };


### PR DESCRIPTION
### Changes
* Fixes issue with auto literal codegen interpreting regex `$` as the character to replace.